### PR TITLE
Errors with larger responses

### DIFF
--- a/pointdns.js
+++ b/pointdns.js
@@ -9,7 +9,7 @@ app.api = {
   timeout: 10000,
 }
 
-function validate(callback, params, list){
+function validate(params, list, callback) {
   for (key in list) {
     if (!(list[key] in params)){
       callback(new Error('param not found: ' + list[key]))
@@ -20,7 +20,7 @@ function validate(callback, params, list){
 }
 
 app.zones = {
-  list: function(callback, params) {
+  list: function(params, callback) {
     var query = ''
     if (typeof params !== 'undefined' && 'group' in params) {
       query = '?group=' + params['group']
@@ -30,23 +30,23 @@ app.zones = {
 }
 
 app.zone = {
-  add: function(callback, fields) {
+  add: function(fields, callback) {
     app.call(201, 'POST', '/zones', callback, {'escape': 'zone', 'fields': {'zone': fields}})
   },
-  update: function(callback, params, fields) {
-    if (!(validate(callback, params, ['zone_id']))) {
+  update: function(params, fields, callback) {
+    if (!(validate(params, ['zone_id'], callback))){
        return
     }
     app.call(202, 'PUT', '/zones' + params['zone_id'], callback, {'escape': 'zone', 'fields': {'zone': fields}})
   },
-  get: function(callback, params) {
-    if (!(validate(callback, params, ['zone_id']))) {
+  get: function(params, callback) {
+    if (!(validate(params, ['zone_id'], callback))) {
        return
     }
     app.call(200, 'GET', '/zones/' + params['zone_id'], callback, {'escape': 'zone'})
   },
-  del: function(callback, params) {
-    if (!(validate(callback, params, ['zone_id']))) {
+  del: function(params, callback) {
+    if (!(validate(params, ['zone_id'], callback))) {
        return
     }
     app.call(202, 'DELETE', '/zones/' + params['zone_id'], callback, {'escape': 'zone'})
@@ -54,8 +54,8 @@ app.zone = {
 }
 
 app.records = {
-  list: function(callback, params) {
-    if (!(validate(callback, params, ['zone_id']))) {
+  list: function(params, callback) {
+    if (!(validate(params, ['zone_id'], callback))) {
        return
     }
     app.call(200, 'GET', '/zones/' + params['zone_id'] + '/records/', callback, {'list_escape': 'zone_record'})
@@ -63,26 +63,26 @@ app.records = {
 }
 
 app.record = {
-  add: function(callback, params, fields) { // zone_record
-    if (!(validate(callback, params, ['zone_id']))) {
+  add: function(params, fields, callback) { // zone_record
+    if (!(validate(params, ['zone_id'], callback))) {
        return
     }
     app.call(201, 'POST', '/zones/' + params['zone_id'] + '/records', callback, { 'escape': 'zone_record', 'fields':{'zone_record': fields} })
   },
-  update: function(callback, params, fields) {  // zone_record
-    if (!(validate(callback, params, ['zone_id', 'record_id']))) {
+  update: function(params, fields, callback) {  // zone_record
+    if (!(validate(params, ['zone_id', 'record_id'], callback))) {
        return
     }
     app.call(202, 'PUT', '/zones/' + params['zone_id'] + '/records' + params['record_id'], callback, { 'escape': 'zone_record', 'fields':{'zone_record': fields} })
   },
-  get: function(callback, params) {  // zone_record
-    if (!(validate(callback, params, ['zone_id', 'record_id']))) {
+  get: function(params, callback) {  // zone_record
+    if (!(validate(params, ['zone_id', 'record_id'], callback))) {
        return
     }
     app.call(200, 'GET', '/zones/' + params['zone_id'] + '/records/' + params['record_id'], callback, {'escape': 'zone_record'})
   },
-  del: function(callback, params) {  //  zone_record
-    if (!(validate(callback, params, ['zone_id', 'record_id']))) {
+  del: function(params, callback) {  //  zone_record
+    if (!(validate(params, ['zone_id', 'record_id'], callback))) {
        return
     }
     app.call(202, 'DELETE', '/zones/' + params['zone_id'] + '/records' + params['record_id'], callback, {'escape': 'zone_record'})

--- a/pointdns.js
+++ b/pointdns.js
@@ -125,9 +125,12 @@ app.call = function(status, method, path, callback, data) {
       callback( new Error('http error') )
       return
     }
-
-    res.on('data', function(d) {
-      result = JSON.parse( d )
+    var responseData = '';
+    res.on('data', function(chunk) {
+      responseData += chunk;
+    });
+    res.on('end', function(){
+      result = JSON.parse( responseData )
       if ('escape' in data) {
         result = result[data['escape']]
       } else if ('list_escape' in data) {
@@ -137,6 +140,7 @@ app.call = function(status, method, path, callback, data) {
         })
         result = tmp
       }
+      req.end();
       callback(null, result)
     });
   });
@@ -171,4 +175,3 @@ module.exports = function( setup ) {
   }
   return app
 }
-


### PR DESCRIPTION
When attempting to run pointdns.records.list on a zone that about 450 records, I get the following:

```
SyntaxError: Unexpected end of input
    at Object.parse (native)
    at IncomingMessage.<anonymous> (/home/controller/app/node_modules/pointdns/pointdns.js:130:21)
    at IncomingMessage.EventEmitter.emit (events.js:95:17)
    at IncomingMessage.<anonymous> (_stream_readable.js:746:14)
    at IncomingMessage.EventEmitter.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:408:10)
    at emitReadable (_stream_readable.js:404:5)
    at readableAddChunk (_stream_readable.js:165:9)
    at IncomingMessage.Readable.push (_stream_readable.js:127:10)
    at HTTPParser.parserOnBody [as onBody] (http.js:142:22)
```

This method works perfectly fine on smaller zones however.

It's also rather common practice with node.js to have callback functions as the final argument to any method. This isn't so much an issue, but a norm that the majority have come to expect and all official packages from the node.js team, as far as I'm aware, follow this structure.

I've submitted a couple commits in this pull request with some changes to the request to handle chunking of data on large responses and to uniform the use of callbacks. I'd also recommend looking at [request.js](https://github.com/mikeal/request) as although it'll add a dependency to the module, it'll make handling requests much tidier and simpler.
