### PR TITLE
Exposes more configurable options including port and http.

### DIFF
--- a/pointdns.js
+++ b/pointdns.js
@@ -1,10 +1,13 @@
 var https = require('https'),
+    http = require('http'),
     app = {
         api: {
             hostname: 'pointhq.com',
+            port: 443,
             username: null,
             apitoken: null,
             timeout: 10000,
+            https: true
         }
     };
 
@@ -102,7 +105,7 @@ app.req = function(status, method, path, data, callback){
         },
         options = {
             host: app.api.hostname,
-            port: 443,
+            port: app.api.port,
             path: path,
             method: method,
             headers: headers,
@@ -113,7 +116,7 @@ app.req = function(status, method, path, data, callback){
     }
 
     //request
-    var req = https.request(options, function(res){
+    var req = (app.api.https ? https : http).request(options, function(res){
         if(res.statusCode == 404){
             return callback('404 response. Incorrect or invalid fields');
         }


### PR DESCRIPTION
I've been integrating with the pointdns API, but I needed to alter the module to allow pointing my tests to a local fake server. These changes help disable https and change the port to something configurable.
